### PR TITLE
Fix changeLanguage alias in HomeLayout

### DIFF
--- a/src/home/HomeLayout.vue
+++ b/src/home/HomeLayout.vue
@@ -56,7 +56,7 @@
 
 <script>
 import ProfessionalExperience from './components/ProfessionalExperience.vue';
-import { changeLanguage } from 'src/_translate/i18nService';
+import { changeLanguage as setLanguage } from 'src/_translate/i18nService';
 
 export default {
     components: {
@@ -65,7 +65,7 @@ export default {
     data() {
         return {
             changeLanguage(lang) {
-                changeLanguage(lang)
+                setLanguage(lang)
             },
             titulo: "MatDevFolio</>",
             stacksPrincipais: ['Angular', 'Dotnet ( ASP.NET Core )', 'Nodejs ( Nestjs )', 'Flutter', 'Vuejs'],


### PR DESCRIPTION
## Summary
- alias `changeLanguage` import as `setLanguage`
- call the alias in the data method

## Testing
- `npm run lint` *(fails: ESLint couldn't find eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_6842fa4c1000832593e9361f6a292a47